### PR TITLE
Create new schedule v2

### DIFF
--- a/planetti-ui/package-lock.json
+++ b/planetti-ui/package-lock.json
@@ -1226,6 +1226,94 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
     "@eslint/eslintrc": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
@@ -3135,6 +3223,30 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -3172,6 +3284,11 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
       "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -6362,6 +6479,11 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9285,6 +9407,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -11945,6 +12072,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
       "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-is": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
@@ -12089,6 +12224,21 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
+      }
+    },
+    "react-select": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.1.tgz",
+      "integrity": "sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
       }
     },
     "react-toastify": {

--- a/planetti-ui/package.json
+++ b/planetti-ui/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "react-select": "^3.1.1",
     "react-toastify": "^6.0.9",
     "web-vitals": "^0.2.4"
   },

--- a/planetti-ui/src/App.jsx
+++ b/planetti-ui/src/App.jsx
@@ -13,7 +13,7 @@ import UserPage from "./components/Userpage";
 import ViewSchedule from "./components/ViewSchedule";
 import UserSettings from "./components/UserSettings";
 import Footer from "./components/common/Footer";
-
+import NewSchedule from "./components/NewSchedule";
 /* Styles
 ----------*/
 import "react-toastify/dist/ReactToastify.css";
@@ -72,21 +72,22 @@ const App = () => {
       />
       <Switch>
         <Route
+          path="/new-schedule"
+          render={(routeProps) => <NewSchedule {...routeProps} />}
+        />
+        <Route
           path="/login"
-          render={routeProps => (
-            <Signin
-              signin={handleSignin}
-              {...routeProps} />
+          render={(routeProps) => (
+            <Signin signin={handleSignin} {...routeProps} />
           )}
         />
         <Route
           path="/view-schedule/:uuid"
-          render={routeProps => (
-            <ViewSchedule {...routeProps} />)}
+          render={(routeProps) => <ViewSchedule {...routeProps} />}
         />
         <Route
           path="/user-settings"
-          render={routeProps =>
+          render={(routeProps) =>
             loggedIn && (
               <UserSettings
                 deleteFeedBack={handleAccountDelete}
@@ -97,7 +98,8 @@ const App = () => {
           }
         />
         <Route
-          path="/" exact
+          path="/"
+          exact
           render={(routeProps) => {
             if (!loggedIn) return <NotLogged {...routeProps} />;
             return <UserPage />;

--- a/planetti-ui/src/App.jsx
+++ b/planetti-ui/src/App.jsx
@@ -17,6 +17,7 @@ import NewSchedule from "./components/NewSchedule";
 /* Styles
 ----------*/
 import "react-toastify/dist/ReactToastify.css";
+import styles from "./assets/css/main-page.module.css";
 
 const App = () => {
   const [loggedIn, setLoggedIn] = useState(null);
@@ -57,58 +58,61 @@ const App = () => {
 
   return (
     <>
-      <ToastContainer
-        autoClose={3000}
-        hideProgressBar={true}
-        pauseOnHover={false}
-        pauseOnFocusLose={false}
-        closeButton={false}
-        limit={1}
-      />
-      <NavBar
-        siteName="Planetti"
-        userName={loggedIn && loggedIn.name}
-        onLogout={handleSignout}
-      />
-      <Switch>
-        <Route
-          path="/new-schedule"
-          render={(routeProps) => <NewSchedule {...routeProps} />}
+      <div className={styles.wrap}>
+        <ToastContainer
+          autoClose={3000}
+          hideProgressBar={true}
+          pauseOnHover={false}
+          pauseOnFocusLose={false}
+          closeButton={false}
+          limit={1}
         />
-        <Route
-          path="/login"
-          render={(routeProps) => (
-            <Signin signin={handleSignin} {...routeProps} />
-          )}
+
+        <NavBar
+          siteName="Planetti"
+          userName={loggedIn && loggedIn.name}
+          onLogout={handleSignout}
         />
-        <Route
-          path="/view-schedule/:uuid"
-          render={(routeProps) => <ViewSchedule {...routeProps} />}
-        />
-        <Route
-          path="/user-settings"
-          render={(routeProps) =>
-            loggedIn && (
-              <UserSettings
-                deleteFeedBack={handleAccountDelete}
-                profileFeedBack={handleProfileChanged}
-                {...routeProps}
-              />
-            )
-          }
-        />
-        <Route
-          path="/"
-          exact
-          render={(routeProps) => {
-            if (!loggedIn) return <NotLogged {...routeProps} />;
-            return <UserPage />;
-          }}
-        />
-        {/* <Route
+        <Switch>
+          <Route
+            path="/new-schedule"
+            render={(routeProps) => <NewSchedule {...routeProps} />}
+          />
+          <Route
+            path="/login"
+            render={(routeProps) => (
+              <Signin signin={handleSignin} {...routeProps} />
+            )}
+          />
+          <Route
+            path="/view-schedule/:uuid"
+            render={(routeProps) => <ViewSchedule {...routeProps} />}
+          />
+          <Route
+            path="/user-settings"
+            render={(routeProps) =>
+              loggedIn && (
+                <UserSettings
+                  deleteFeedBack={handleAccountDelete}
+                  profileFeedBack={handleProfileChanged}
+                  {...routeProps}
+                />
+              )
+            }
+          />
+          <Route
+            path="/"
+            exact
+            render={(routeProps) => {
+              if (!loggedIn) return <NotLogged {...routeProps} />;
+              return <UserPage />;
+            }}
+          />
+          {/* <Route
           path="*"
           render={() => <h1>Not Found</h1>} /> */}
-      </Switch>
+        </Switch>
+      </div>
       <Footer />
     </>
   );

--- a/planetti-ui/src/assets/css/delete-account.module.css
+++ b/planetti-ui/src/assets/css/delete-account.module.css
@@ -52,3 +52,18 @@
   margin: auto;
   padding: 5px;
 }
+
+.createPageContainer
+{
+  display: flex;
+  flex-direction: column;
+  max-width: 50%;
+  justify-content: center;
+  align-items: center;
+  margin: auto;
+}
+
+.buttonBar {
+  display: flex;
+  justify-content: space-between;
+}

--- a/planetti-ui/src/assets/css/delete-account.module.css
+++ b/planetti-ui/src/assets/css/delete-account.module.css
@@ -11,3 +11,44 @@
 .modal-body {
   justify-content: space-between !important;
 }
+
+.selectedColor
+{
+  min-width: 80px;
+  min-height: 30px;
+  background-color: ivory;
+}
+
+.colorButton
+{
+  min-width: 80px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Russo One", sans-serif;
+  color: white;
+  padding: 5px;
+  margin: 10px;
+}
+
+:hover .colorButton
+{
+  cursor: pointer;
+}
+
+.colorContainer
+{
+  width: 10%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 10px;
+}
+
+.colorLabel
+{
+  white-space: nowrap;
+  margin: auto;
+  padding: 5px;
+}

--- a/planetti-ui/src/assets/css/main-page.module.css
+++ b/planetti-ui/src/assets/css/main-page.module.css
@@ -1,0 +1,7 @@
+  .wrap{
+    display:flex;
+    flex-direction: column;
+    justify-content: start;
+    background-color: #F2F2F8;
+    min-height: 94vh;
+}

--- a/planetti-ui/src/assets/css/userpage.module.css
+++ b/planetti-ui/src/assets/css/userpage.module.css
@@ -68,7 +68,6 @@
 }
 
 .card_style {
-  background-color: #16a3a3 !important;
   border-color: transparent !important;
   display: inline-block;
   size: 100%;

--- a/planetti-ui/src/components/ColorPicker.jsx
+++ b/planetti-ui/src/components/ColorPicker.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import styles from "../assets/css/delete-account.module.css";
+
+function ColorPicker(props) {
+  function chooseColor(event) {
+    props.chooseColor(event.target.id);
+  }
+
+  return (
+    <div>
+      <label className="form-control">Colors</label>
+      <div className={styles.colorContainer}>
+        <div className={styles.colorLabel}> Selected Color: </div>
+        <div
+          className={styles.selectedColor}
+          style={{ backgroundColor: props.chosenColor }}
+        >
+          {" "}
+        </div>
+        <div className={styles.colorLabel}> Available Colors: </div>
+        <div
+          className={styles.colorButton}
+          id="#16a3a3"
+          style={{ backgroundColor: "#16a3a3" }}
+          onClick={chooseColor}
+        >
+          {" "}
+          Default{" "}
+        </div>
+        <div
+          className={styles.colorButton}
+          id="#f3947c"
+          style={{ backgroundColor: "#f3947c" }}
+          onClick={chooseColor}
+        >
+          {" "}
+          Peach
+        </div>
+        <div
+          className={styles.colorButton}
+          id="#a693bc"
+          style={{ backgroundColor: "#a693bc" }}
+          onClick={chooseColor}
+        >
+          {" "}
+          Lilac
+        </div>
+        <div
+          className={styles.colorButton}
+          id="#353839"
+          style={{ backgroundColor: "#353839" }}
+          onClick={chooseColor}
+        >
+          {" "}
+          Onyx
+        </div>
+        <div
+          className={styles.colorButton}
+          id="#e39e59"
+          style={{ backgroundColor: "#e39e59" }}
+          onClick={chooseColor}
+        >
+          {" "}
+          Ochre
+        </div>
+      </div>
+    </div>
+  );
+}
+export default ColorPicker;

--- a/planetti-ui/src/components/CreateUI.jsx
+++ b/planetti-ui/src/components/CreateUI.jsx
@@ -1,4 +1,5 @@
 import Select from "react-select";
+
 const options = [
   { value: "text", label: "Text" },
   { value: "number", label: "Only Numbers" },
@@ -22,7 +23,8 @@ const customStylesSelect = {
     return { ...provided, opacity, transition };
   },
 };
-export default createUI = (props) => {
+
+function CreateUI(props) {
   return props.map((el, i) => (
     <div key={i}>
       <div>
@@ -57,4 +59,6 @@ export default createUI = (props) => {
       </div>
     </div>
   ));
-};
+}
+
+export default CreateUI;

--- a/planetti-ui/src/components/CreateUI.jsx
+++ b/planetti-ui/src/components/CreateUI.jsx
@@ -1,0 +1,60 @@
+import Select from "react-select";
+const options = [
+  { value: "text", label: "Text" },
+  { value: "number", label: "Only Numbers" },
+  { value: "email", label: "Email" },
+  { value: "url", label: "Url" },
+];
+const customStylesSelect = {
+  menu: (provided, state) => ({
+    ...provided,
+    width: state.selectProps.width,
+    borderBottom: "250px dotted pink",
+    color: state.selectProps.menuColor,
+    padding: 20,
+  }),
+  control: (_, { selectProps: { width } }) => ({
+    width: width,
+  }),
+  singleValue: (provided, state) => {
+    const opacity = state.isDisabled ? 0.5 : 1;
+    const transition = "opacity 300ms";
+    return { ...provided, opacity, transition };
+  },
+};
+export default createUI = (props) => {
+  return props.map((el, i) => (
+    <div key={i}>
+      <div>
+        <input
+          name={el.value + " "}
+          type="text"
+          value={el.value}
+          onChange={(e) => this.handleChangesInput(e, i)}
+        />
+        <Select
+          value={el.selectedOption}
+          onChange={(e) => this.handleChangeSelect(e, i)}
+          options={options}
+          width="200px"
+          menuColor="red"
+          styles={customStylesSelect}
+          name="select"
+        />
+        Is Mandatory? :
+        <input
+          name="isMandatory"
+          type="checkbox"
+          defaultChecked={false}
+          checked={el.isMandatory}
+          onChange={(e) => this.handleCheckBox(e, i)}
+        />
+        <input
+          type="button"
+          value="remove"
+          onClick={this.removeClick.bind(this, i)}
+        />
+      </div>
+    </div>
+  ));
+};

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -5,7 +5,7 @@ import Select from "react-select";
 import { newSchedule } from "../services/scheduleService";
 import styles from "../assets/css/delete-account.module.css";
 import Joi from "joi";
-import { createUI } from "../components/CreateUI";
+//import  CreateUI  from "../components/CreateUI";
 import ColorPicker from "../components/ColorPicker";
 
 const options = [
@@ -26,7 +26,6 @@ class NewSchedule extends Form {
     selectedOption: null,
     start_date: "",
     end_date: "",
-    title: "",
     description: "",
     chosenColor: "#16a3a3",
     showDatePicker: "",
@@ -35,6 +34,8 @@ class NewSchedule extends Form {
 
   schema = Joi.object({
     title: Joi.string().required(),
+    start_date: Joi.date().allow(null, ""),
+    end_date: Joi.date().greater(Joi.ref("start_date")).allow(null, ""),
   });
 
   backToUserpage = () => {
@@ -130,22 +131,17 @@ class NewSchedule extends Form {
     this.setState({ customFields });
   };
 
-  // handleSubmit = (event) => {
-  //   event.preventDefault();
-  //   console.log(this.state.customFields);
-  // };
-
   doSubmit = async () => {
     let customFieldsSpread = [...this.state.customFields];
     const userInfo = localStorage.getItem("userInfo");
     const { user_id } = JSON.parse(userInfo);
     let scheduleData = {
-      title: this.state.description,
+      title: this.state.data.title,
       description: this.state.description,
       user_id: user_id,
       schedule_config: {
-        maxDate: this.state.start_date,
-        minDate: this.state.end_date,
+        maxDate: this.state.data.end_date,
+        minDate: this.state.data.start_date,
         fields: customFieldsSpread,
       },
       schedule_color: this.state.chosenColor,
@@ -172,8 +168,15 @@ class NewSchedule extends Form {
                 <label>Give your schedule a Title</label>
                 <input
                   className="form-control"
-                  value={this.state.title || ""}
-                  onChange={(e) => this.setState({ title: e.target.value })}
+                  value={this.state.data.title || ""}
+                  onChange={(e) =>
+                    this.setState((prevState) => ({
+                      data: {
+                        ...prevState.data,
+                        title: e.target.value,
+                      },
+                    }))
+                  }
                 />
                 {this.state.errors.title && (
                   <small className="text-danger">
@@ -211,23 +214,45 @@ class NewSchedule extends Form {
               />
               {this.state.showDatePicker && (
                 <div>
+                  <div>
+                    {this.state.errors.start_date && (
+                      <small className="text-danger">
+                        {this.state.errors.start_date}
+                      </small>
+                    )}
+                  </div>
                   <label>Start date</label>
                   <input
                     type="date"
                     name="start_date"
-                    value={this.state.start_date}
+                    value={this.state.data.start_date}
                     onChange={(e) =>
-                      this.setState({ start_date: e.target.value })
+                      this.setState((prevState) => ({
+                        data: {
+                          ...prevState.data,
+                          start_date: e.target.value,
+                        },
+                      }))
                     }
                   />
                   <div>
+                    {this.state.errors.end_date && (
+                      <small className="text-danger">
+                        {this.state.errors.end_date}
+                      </small>
+                    )}
                     <label> End date</label>
                     <input
                       type="date"
                       name="end_date"
-                      value={this.state.end_date}
+                      value={this.state.data.end_date}
                       onChange={(e) =>
-                        this.setState({ end_date: e.target.value })
+                        this.setState((prevState) => ({
+                          data: {
+                            ...prevState.data,
+                            end_date: e.target.value,
+                          },
+                        }))
                       }
                     />
                   </div>
@@ -249,7 +274,6 @@ class NewSchedule extends Form {
         </form>
         <div>
           <button onClick={this.addClick}>new stuff</button>
-          <input type="submit" value="test submit" />
         </div>
       </div>
     );

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -15,6 +15,8 @@ const options = [
   { value: "url", label: "Url" },
 ];
 
+const todayDate = new Date();
+
 class NewSchedule extends Form {
   state = {
     data: {
@@ -34,8 +36,8 @@ class NewSchedule extends Form {
 
   schema = Joi.object({
     title: Joi.string().required(),
-    start_date: Joi.date().allow(null, ""),
-    end_date: Joi.date().greater(Joi.ref("start_date")).allow(null, ""),
+    start_date: Joi.date().allow(""),
+    end_date: Joi.date().min(Joi.ref("start_date")).allow("")
   });
 
   backToUserpage = () => {
@@ -157,9 +159,28 @@ class NewSchedule extends Form {
     this.setState({ chosenColor: color });
   };
 
+  DatePickerHandler = (e) =>
+  {
+    
+    this.state.showDatePicker ?
+    
+    this.setState({
+     // showDatePicker: e.target.checked,
+     data : { start_date: "", end_date: ""}
+     
+    })
+    :
+    this.setState({
+     // showDatePicker: e.target.checked,
+
+      data : { start_date: todayDate.toISOString().slice(0,10) , end_date : todayDate.toISOString().slice(0,10) }
+    })
+
+  }
+
   render() {
     return (
-      <div>
+      <div className={styles.createPageContainer}>
         <form onSubmit={null}>
           <div>
             <div>
@@ -200,6 +221,7 @@ class NewSchedule extends Form {
               chooseColor={this.chooseColor}
               chosenColor={this.state.chosenColor}
             />
+
             <div>
               Want to have custom schedule duration?{" "}
               <input
@@ -207,9 +229,17 @@ class NewSchedule extends Form {
                 name="showDatePicker"
                 checked={this.state.showDatePicker}
                 onChange={(e) => {
+                
+                 
                   this.setState({
                     showDatePicker: e.target.checked,
+                    // data : { start_date: todayDate.toISOString().slice(0,10)}
                   });
+                  this.DatePickerHandler(e);
+                  console.log(this.state.data.start_date);
+                  
+                  
+
                 }}
               />
               {this.state.showDatePicker && (
@@ -259,7 +289,7 @@ class NewSchedule extends Form {
                 </div>
               )}
             </div>
-            <div>
+            <div className={styles.buttonBar}>
               <Button className={styles.cancel} onClick={this.backToUserpage}>
                 Back
               </Button>

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -5,7 +5,7 @@ import Select from "react-select";
 import { newSchedule } from "../services/scheduleService";
 import styles from "../assets/css/delete-account.module.css";
 import Joi from "joi";
-
+import { createUI } from "../components/CreateUI";
 const options = [
   { value: "text", label: "Text" },
   { value: "number", label: "Only Numbers" },
@@ -17,6 +17,8 @@ class NewSchedule extends Form {
   state = {
     data: {
       title: "",
+      start_date: "",
+      end_date: "",
     },
     customFields: [],
     selectedOption: null,
@@ -25,6 +27,7 @@ class NewSchedule extends Form {
     title: "",
     description: "",
     chosenColor: "#16a3a3",
+    showDatePicker: "",
     errors: {},
   };
 
@@ -56,7 +59,6 @@ class NewSchedule extends Form {
       return { ...provided, opacity, transition };
     },
   };
-  // stuff for new inputs
   createUI = () => {
     return this.state.customFields.map((el, i) => (
       <div key={i}>
@@ -68,8 +70,8 @@ class NewSchedule extends Form {
             onChange={(e) => this.handleChangesInput(e, i)}
           />
           <Select
-            value={this.state.customFields[i].selectedOption}
-            onChange={this.handleChangeSelect.bind(this, i)}
+            value={el.selectedOption}
+            onChange={(e) => this.handleChangeSelect(e, i)}
             options={options}
             width="200px"
             menuColor="red"
@@ -81,8 +83,8 @@ class NewSchedule extends Form {
             name="isMandatory"
             type="checkbox"
             defaultChecked={false}
-            checked={this.state.customFields[i].isMandatory}
-            onChange={this.handleCheckBox.bind(this, i)}
+            checked={el.isMandatory}
+            onChange={(e) => this.handleCheckBox(e, i)}
           />
           <input
             type="button"
@@ -100,15 +102,15 @@ class NewSchedule extends Form {
     this.setState({ customFields });
   };
 
-  handleChangeSelect = (i, event) => {
+  handleChangeSelect = (e, i) => {
     let customFields = [...this.state.customFields];
-    customFields[i] = { ...customFields[i], select: event.value };
+    customFields[i] = { ...customFields[i], select: e.value };
     this.setState({ customFields });
   };
 
-  handleCheckBox = (i, event) => {
+  handleCheckBox = (e, i) => {
     let customFields = [...this.state.customFields];
-    customFields[i] = { ...customFields[i], isMandatory: event.target.checked };
+    customFields[i] = { ...customFields[i], isMandatory: e.target.checked };
     this.setState({ customFields });
   };
 
@@ -176,8 +178,9 @@ class NewSchedule extends Form {
                     {this.state.errors.title}
                   </small>
                 )}
-
-                <label>Please give a short description</label>
+                <label>
+                  Please give a short description if you want (Optional)
+                </label>
                 <input
                   className="form-control"
                   value={this.state.description || ""}
@@ -247,22 +250,42 @@ class NewSchedule extends Form {
               </div>
             </div>
             <div>
+              Want to have custom schedule duration?{" "}
               <input
-                type="date"
-                name="start_date"
-                value={this.state.start_date}
-                onChange={(e) => this.setState({ start_date: e.target.value })}
+                type="checkbox"
+                name="showDatePicker"
+                checked={this.state.showDatePicker}
+                onChange={(e) => {
+                  this.setState({
+                    showDatePicker: e.target.checked,
+                  });
+                }}
               />
-              <input
-                type="date"
-                name="end_date"
-                value={this.state.end_date}
-                onChange={(e) => this.setState({ end_date: e.target.value })}
-              />
-              {/* {console.log(this.state.start_date)}
-              {console.log(this.state.end_date)} */}
+              {this.state.showDatePicker && (
+                <div>
+                  <label>Start date</label>
+                  <input
+                    type="date"
+                    name="start_date"
+                    value={this.state.start_date}
+                    onChange={(e) =>
+                      this.setState({ start_date: e.target.value })
+                    }
+                  />
+                  <div>
+                    <label> End date</label>
+                    <input
+                      type="date"
+                      name="end_date"
+                      value={this.state.end_date}
+                      onChange={(e) =>
+                        this.setState({ end_date: e.target.value })
+                      }
+                    />
+                  </div>
+                </div>
+              )}
             </div>
-            {/* button div */}
             <div>
               <Button className={styles.cancel} onClick={this.backToUserpage}>
                 Back

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Component } from "react";
-import { Modal, Button } from "react-bootstrap";
+import { Button } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 import Select from "react-select";
 
@@ -13,96 +13,152 @@ const options = [
 ];
 class NewSchedule extends Component {
   state = {
+    values: [],
+    stuff: [],
     selectedOption: null,
     start_date: Date,
     end_date: Date,
     title: "",
-    updateTitle: "",
     description: "",
-    updateDescription: "",
   };
   backToUserpage = () => {
     useHistory.push("/");
   };
 
-  handleChange(e) {
-    this.setState({ id: e.value, name: e.label });
-  }
   handleChange = (selectedOption) => {
     this.setState({ selectedOption });
-    console.log(`Option selected:`, selectedOption);
+
+    this.addClick(selectedOption);
+  };
+
+  // stuff for new inputs
+  createUI = () => {
+    return this.state.values.map((el, i) => (
+      <div key={i}>
+        <h1>
+          {el.label + " "}
+          <label>
+            Is Mandatory? :
+            <input
+              name="isMandatory"
+              type="checkbox"
+              checked={this.state.values[i].isMandatory}
+              onChange={this.handleChanges.bind(this, i)}
+            />
+          </label>
+          <input
+            name={el.value + " "}
+            type="input"
+            value={this.state.values[i].value}
+            onChange={this.handleChanges.bind(this, i)}
+          />
+        </h1>
+        <input
+          type="button"
+          value="remove"
+          onClick={this.removeClick.bind(this, i)}
+        />
+      </div>
+    ));
+  };
+
+  handleChanges = (i, event) => {
+    let values = [...this.state.values];
+    values[i] = { ...values[i], isMandatory: event.target.checked };
+
+    this.setState({ values });
+  };
+
+  addClick = (selectedOption) => {
+    this.setState((prevState) => ({
+      values: [...prevState.values, selectedOption],
+    }));
+  };
+
+  removeClick = (i) => {
+    let values = [...this.state.values];
+    values.splice(i, 1);
+    this.setState({ values });
+  };
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+    console.log(this.state.values);
   };
 
   render() {
     const { selectedOption } = this.state;
+
     return (
       <div>
-        <div>
+        <form onSubmit={this.handleSubmit}>
           <div>
-            {/* required inputs */}
-            <div className="form-group">
-              <label>Give your schedule a Title</label>
-              <input
-                className="form-control"
-                value={this.state.title || ""}
-                onChange={(e) => this.updateTitle(e.target.value)}
-              />
-              <label>Please give a short description</label>
-              <input
-                className="form-control"
-                value={this.state.description || ""}
-                onChange={(e) => this.updateDescription(e.target.value)}
-              />
-            </div>
-          </div>
-          <div>
-            <Select
-              value={selectedOption}
-              onChange={this.handleChange}
-              options={options}
-            />
-            {/* extra stuff */}
             <div>
-              <button>Add new stuff</button>
+              {/* required inputs */}
+              <div className="form-group">
+                <label>Give your schedule a Title</label>
+                <input
+                  className="form-control"
+                  value={this.state.title || ""}
+                  onChange={(e) => this.setState({ title: e.target.value })}
+                />
+                <label>Please give a short description</label>
+                <input
+                  className="form-control"
+                  value={this.state.description || ""}
+                  onChange={(e) =>
+                    this.setState({ description: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <div>
+              <Select
+                value={selectedOption}
+                onChange={this.handleChange}
+                options={options}
+              />
+              {/* extra stuff */}
+              {this.createUI()}
+              <input type="submit" value="test submit" />
+            </div>
+            <div>
+              <div>Here be the colors? RGB color wheel?</div>
+              <input name="color picker" type="color"></input>
+            </div>
+            <div>
+              two data input fields here?
+              <input
+                type="date"
+                name="start_date"
+                value={this.state.start_date || ""}
+                onChange={(e) => this.setState({ start_date: e.target.value })}
+              />
+              <input
+                type="date"
+                name="end_date"
+                value={this.state.end_date || ""}
+                onChange={(e) => this.setState({ end_date: e.target.value })}
+              />
+              {/* {console.log(this.state.start_date)}
+              {console.log(this.state.end_date)} */}
+            </div>
+            {/* button div */}
+            <div>
+              <Button className={styles.cancel} onClick={this.backToUserpage}>
+                Back
+              </Button>
+              <Button
+                className="btn-success"
+                onClick={() => {
+                  this.handleNewSchedule();
+                }}
+              >
+                Create this schedule
+              </Button>
             </div>
           </div>
-          <div>
-            <div>Here be the colors? RGB color wheel?</div>
-            <input name="color picker" type="color"></input>
-          </div>
-          <div>
-            two data input fields here?
-            <input
-              type="date"
-              name="start_date"
-              value={this.state.start_date || ""}
-              onChange={(e) => this.setState({ start_date: e.target.value })}
-            />
-            <input
-              type="date"
-              name="end_date"
-              value={this.state.end_date || ""}
-              onChange={(e) => this.setState({ end_date: e.target.value })}
-            />
-            {console.log(this.state.start_date)}
-            {console.log(this.state.end_date)}
-            {/* somehow also to do endless? no end date */}
-          </div>
-          {/* button div */}
-          <div>
-            <Button className={styles.cancel} onClick={this.backToUserpage}>
-              Back
-            </Button>
-            <Button
-              className="btn-success"
-              onClick={() => {
-                this.handleNewSchedule();
-              }}
-            >
-              Create this schedule
-            </Button>
-          </div>
-        </div>
+        </form>
       </div>
     );
   }

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -3,6 +3,7 @@ import { Component } from "react";
 import { Button, ToastBody } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 import Select from "react-select";
+import { newSchedule } from "../services/scheduleService";
 
 import styles from "../assets/css/delete-account.module.css";
 
@@ -16,7 +17,7 @@ const todayDate = new Date();
 
 class NewSchedule extends Component {
   state = {
-    values: [],
+    customFields: [],
     selectedOption: null,
     start_date: todayDate.toISOString().slice(0, 10),
     end_date: todayDate.toISOString().slice(0, 10),
@@ -25,6 +26,9 @@ class NewSchedule extends Component {
   };
   backToUserpage = () => {
     useHistory.push("/");
+  };
+  routeChange = (path) => {
+    useHistory.push("/view-schedule/" + path);
   };
   customStylesSelect = {
     menu: (provided, state) => ({
@@ -45,17 +49,17 @@ class NewSchedule extends Component {
   };
   // stuff for new inputs
   createUI = () => {
-    return this.state.values.map((el, i) => (
+    return this.state.customFields.map((el, i) => (
       <div key={i}>
         <div>
           <input
             name={el.value + " "}
             type="input"
-            value={this.state.values[i].value}
+            value={this.state.customFields[i].value}
             onChange={this.handleChangesInput.bind(this, i)}
           />
           <Select
-            value={this.state.values[i].selectedOption}
+            value={this.state.customFields[i].selectedOption}
             onChange={this.handleChangeSelect.bind(this, i)}
             options={options}
             width="200px"
@@ -68,7 +72,7 @@ class NewSchedule extends Component {
             name="isMandatory"
             type="checkbox"
             defaultChecked={false}
-            checked={this.state.values[i].isMandatory}
+            checked={this.state.customFields[i].isMandatory}
             onChange={this.handleCheckBox.bind(this, i)}
           />
           <input
@@ -82,43 +86,70 @@ class NewSchedule extends Component {
   };
 
   handleChangesInput = (i, event) => {
-    let values = [...this.state.values];
-    values[i] = { ...values[i], input: event.target.value };
-    this.setState({ values });
+    let customFields = [...this.state.customFields];
+    customFields[i] = { ...customFields[i], input: event.target.value };
+    this.setState({ customFields });
   };
 
   handleChangeSelect = (i, event) => {
-    let values = [...this.state.values];
-    values[i] = { ...values[i], select: event.value };
-    this.setState({ values });
+    let customFields = [...this.state.customFields];
+    customFields[i] = { ...customFields[i], select: event.value };
+    this.setState({ customFields });
   };
 
   handleCheckBox = (i, event) => {
-    let values = [...this.state.values];
-    values[i] = { ...values[i], isMandatory: event.target.checked };
-    this.setState({ values });
+    let customFields = [...this.state.customFields];
+    customFields[i] = { ...customFields[i], isMandatory: event.target.checked };
+    this.setState({ customFields });
   };
 
   addClick = () => {
+    let id = this.state.customFields.length + 1;
+    let test = { id: id };
     this.setState((prevState) => ({
-      values: [...prevState.values, {}],
+      customFields: [...prevState.customFields, test],
     }));
   };
 
   removeClick = (i) => {
-    let values = [...this.state.values];
-    values.splice(i, 1);
-    this.setState({ values });
+    let customFields = [...this.state.customFields];
+    customFields.splice(i, 1);
+    this.setState({ customFields });
   };
 
   handleSubmit = (event) => {
     event.preventDefault();
-    console.log(this.state.values);
+    console.log(this.state.customFields);
   };
 
-  handleNewSchedule = () => {
-    alert("hello");
+  handleNewSchedule = async () => {
+    console.log(this.state);
+    console.log(this.state.customFields);
+    let customFieldsSpread = { ...this.state.customFields };
+    console.log(customFieldsSpread);
+    const userInfo = localStorage.getItem("userInfo");
+    const { user_id } = JSON.parse(userInfo);
+
+    let scheduleData = {
+      title: this.state.description,
+      description: this.state.description,
+      user_id: user_id,
+      maxDate: this.state.start_date,
+      minDate: this.state.end_date,
+      schedule_config: {
+        id: "1",
+        name: "phoneNumber",
+        label: "Phone Number",
+        type: "number",
+        mandatory: "true",
+      },
+      schedule_color: "#16a3a3",
+    };
+    console.log(scheduleData);
+    scheduleData = await newSchedule(scheduleData);
+    this.routeChange(scheduleData[0].uuid);
   };
+
   render() {
     return (
       <div>

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -23,7 +23,7 @@ class NewSchedule extends Component {
     end_date: todayDate.toISOString().slice(0, 10),
     title: "",
     description: "",
-    chosenColor: "#16a3a3"
+    chosenColor: "#16a3a3",
   };
   backToUserpage = () => {
     useHistory.push("/");
@@ -151,15 +151,11 @@ class NewSchedule extends Component {
     this.routeChange(scheduleData[0].uuid);
   };
 
-  chooseColor = (event) =>
-  {
+  chooseColor = (event) => {
     event.preventDefault();
     console.log(event.target.id);
-    this.setState( { chosenColor: event.target.id } )
-  }
-  render() {
-    const { selectedOption } = this.state;
-
+    this.setState({ chosenColor: event.target.id });
+  };
   render() {
     return (
       <div>
@@ -190,23 +186,66 @@ class NewSchedule extends Component {
               {this.createUI()}
               <input type="submit" value="test submit" />
             </div>
-                  
-                  <div>
-                  <label className="form-control">Colors</label>
-                  <div className={styles.colorContainer}>
-                  <div className={styles.colorLabel}> Selected Color: </div>
-                  <div className={styles.selectedColor} style={{backgroundColor:this.state.chosenColor}}> </div>
-                  <div className={styles.colorLabel}> Available Colors: </div>
-                  <div className={styles.colorButton} id="#16a3a3" style={{backgroundColor:'#16a3a3'}} onClick={this.chooseColor}> Default </div>
-                  <div className={styles.colorButton} id="#f3947c" style={{backgroundColor:'#f3947c'}} onClick={this.chooseColor}> Peach</div>
-                  <div className={styles.colorButton} id="#a693bc" style={{backgroundColor:'#a693bc'}} onClick={this.chooseColor}> Lilac</div>
-                  <div className={styles.colorButton} id="#353839" style={{backgroundColor:'#353839'}} onClick={this.chooseColor}> Onyx</div>
-                  <div className={styles.colorButton} id="#e39e59" style={{backgroundColor:'#e39e59'}} onClick={this.chooseColor}> Ochre</div>
-                  </div>
-                  
-                  </div>
-                  
-                
+
+            <div>
+              <label className="form-control">Colors</label>
+              <div className={styles.colorContainer}>
+                <div className={styles.colorLabel}> Selected Color: </div>
+                <div
+                  className={styles.selectedColor}
+                  style={{ backgroundColor: this.state.chosenColor }}
+                >
+                  {" "}
+                </div>
+                <div className={styles.colorLabel}> Available Colors: </div>
+                <div
+                  className={styles.colorButton}
+                  id="#16a3a3"
+                  style={{ backgroundColor: "#16a3a3" }}
+                  onClick={this.chooseColor}
+                >
+                  {" "}
+                  Default{" "}
+                </div>
+                <div
+                  className={styles.colorButton}
+                  id="#f3947c"
+                  style={{ backgroundColor: "#f3947c" }}
+                  onClick={this.chooseColor}
+                >
+                  {" "}
+                  Peach
+                </div>
+                <div
+                  className={styles.colorButton}
+                  id="#a693bc"
+                  style={{ backgroundColor: "#a693bc" }}
+                  onClick={this.chooseColor}
+                >
+                  {" "}
+                  Lilac
+                </div>
+                <div
+                  className={styles.colorButton}
+                  id="#353839"
+                  style={{ backgroundColor: "#353839" }}
+                  onClick={this.chooseColor}
+                >
+                  {" "}
+                  Onyx
+                </div>
+                <div
+                  className={styles.colorButton}
+                  id="#e39e59"
+                  style={{ backgroundColor: "#e39e59" }}
+                  onClick={this.chooseColor}
+                >
+                  {" "}
+                  Ochre
+                </div>
+              </div>
+            </div>
+
             <div>
               two data input fields here?
               <input

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -24,6 +24,7 @@ class NewSchedule extends Component {
     end_date: todayDate.toISOString().slice(0,10),
     title: "",
     description: "",
+    chosenColor: "#16a3a3"
   };
   backToUserpage = () => {
     useHistory.push("/");
@@ -131,6 +132,13 @@ class NewSchedule extends Component {
   handleNewSchedule = () => {
     alert("hello");
   };
+
+  chooseColor = (event) =>
+  {
+    event.preventDefault();
+    console.log(event.target.id);
+    this.setState( { chosenColor: event.target.id } )
+  }
   render() {
     const { selectedOption } = this.state;
 
@@ -163,7 +171,23 @@ class NewSchedule extends Component {
               {this.createUI()}
               <input type="submit" value="test submit" />
             </div>
-              <label>Colors~~~</label>
+                  
+                  <div>
+                  <label className="form-control">Colors</label>
+                  <div className={styles.colorContainer}>
+                  <div className={styles.colorLabel}> Selected Color: </div>
+                  <div className={styles.selectedColor} style={{backgroundColor:this.state.chosenColor}}> </div>
+                  <div className={styles.colorLabel}> Available Colors: </div>
+                  <div className={styles.colorButton} id="#16a3a3" style={{backgroundColor:'#16a3a3'}} onClick={this.chooseColor}> Default </div>
+                  <div className={styles.colorButton} id="#f3947c" style={{backgroundColor:'#f3947c'}} onClick={this.chooseColor}> Peach</div>
+                  <div className={styles.colorButton} id="#a693bc" style={{backgroundColor:'#a693bc'}} onClick={this.chooseColor}> Lilac</div>
+                  <div className={styles.colorButton} id="#353839" style={{backgroundColor:'#353839'}} onClick={this.chooseColor}> Onyx</div>
+                  <div className={styles.colorButton} id="#e39e59" style={{backgroundColor:'#e39e59'}} onClick={this.chooseColor}> Ochre</div>
+                  </div>
+                  
+                  </div>
+                  
+                
             <div>
               two data input fields here?
               <input

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -25,19 +25,16 @@ class NewSchedule extends Component {
     menu: (provided, state) => ({
       ...provided,
       width: state.selectProps.width,
-      borderBottom: "10px dotted pink",
+      borderBottom: "25px dotted pink",
       color: state.selectProps.menuColor,
       padding: 20,
     }),
-
     control: (_, { selectProps: { width } }) => ({
       width: width,
     }),
-
     singleValue: (provided, state) => {
       const opacity = state.isDisabled ? 0.5 : 1;
       const transition = "opacity 300ms";
-
       return { ...provided, opacity, transition };
     },
   };

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -6,10 +6,10 @@ import Select from "react-select";
 
 import styles from "../assets/css/delete-account.module.css";
 const options = [
-  { value: "chocolate", label: "Chocolate" },
-  { value: "strawberry", label: "Strawberry" },
-  { value: "vanilla", label: "Vanilla" },
-  { value: "email", label: "Email" },
+  { value: "chocolate", label: "Chocolate", type: "select" },
+  { value: "strawberry", label: "Strawberry", type: "select" },
+  { value: "vanilla", label: "Vanilla", type: "select" },
+  { value: "email", label: "Email", type: "select" },
 ];
 class NewSchedule extends Component {
   state = {
@@ -24,54 +24,82 @@ class NewSchedule extends Component {
   backToUserpage = () => {
     useHistory.push("/");
   };
+  customStylesSelect = {
+    menu: (provided, state) => ({
+      ...provided,
+      width: state.selectProps.width,
+      borderBottom: "10px dotted pink",
+      color: state.selectProps.menuColor,
+      padding: 20,
+    }),
+
+    control: (_, { selectProps: { width } }) => ({
+      width: width,
+    }),
+
+    singleValue: (provided, state) => {
+      const opacity = state.isDisabled ? 0.5 : 1;
+      const transition = "opacity 300ms";
+
+      return { ...provided, opacity, transition };
+    },
+  };
 
   handleChange = (selectedOption) => {
     this.setState({ selectedOption });
-
-    this.addClick(selectedOption);
   };
 
   // stuff for new inputs
   createUI = () => {
     return this.state.values.map((el, i) => (
       <div key={i}>
-        <h1>
-          {el.label + " "}
-          <label>
-            Is Mandatory? :
-            <input
-              name="isMandatory"
-              type="checkbox"
-              checked={this.state.values[i].isMandatory}
-              onChange={this.handleChanges.bind(this, i)}
-            />
-          </label>
+        <div>
           <input
             name={el.value + " "}
             type="input"
             value={this.state.values[i].value}
             onChange={this.handleChanges.bind(this, i)}
           />
-        </h1>
-        <input
-          type="button"
-          value="remove"
-          onClick={this.removeClick.bind(this, i)}
-        />
+          <Select
+            value={this.state.values[i].selectedOption}
+            onChange={this.handleChanges.bind(this, i)}
+            options={options}
+            width="200px"
+            menuColor="red"
+            styles={this.customStylesSelect}
+            name="select"
+          />
+          Is Mandatory? :
+          <input
+            name="isMandatory"
+            type="checkbox"
+            defaultChecked={false}
+            checked={this.state.values[i].isMandatory}
+            onChange={this.handleChanges.bind(this, i)}
+          />
+          <input
+            type="button"
+            value="remove"
+            onClick={this.removeClick.bind(this, i)}
+          />
+        </div>
       </div>
     ));
   };
 
-  handleChanges = (i, event) => {
+  handleChanges = (i, event, props) => {
+    console.log(i);
+    console.log(event);
+    console.log(props);
     let values = [...this.state.values];
-    values[i] = { ...values[i], isMandatory: event.target.checked };
-
+    let type = event.target.type;
+    values[i] = { ...values[i], [type]: event.target.value };
     this.setState({ values });
   };
 
-  addClick = (selectedOption) => {
+  addClick = () => {
     this.setState((prevState) => ({
-      values: [...prevState.values, selectedOption],
+      values: [...prevState.values, {}],
     }));
   };
 
@@ -86,6 +114,9 @@ class NewSchedule extends Component {
     console.log(this.state.values);
   };
 
+  handleNewSchedule = () => {
+    alert("hello");
+  };
   render() {
     const { selectedOption } = this.state;
 
@@ -113,11 +144,7 @@ class NewSchedule extends Component {
               </div>
             </div>
             <div>
-              <Select
-                value={selectedOption}
-                onChange={this.handleChange}
-                options={options}
-              />
+              <button onClick={this.addClick}>new stuff</button>
               {/* extra stuff */}
               {this.createUI()}
               <input type="submit" value="test submit" />

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -6,16 +6,13 @@ import Select from "react-select";
 
 import styles from "../assets/css/delete-account.module.css";
 const options = [
-  { value: "chocolate", label: "Chocolate", type: "select" },
-  { value: "strawberry", label: "Strawberry", type: "select" },
-  { value: "vanilla", label: "Vanilla", type: "select" },
-  { value: "email", label: "Email", type: "select" },
+  { value: "text", label: "text" },
+  { value: "number", label: "number" },
+  { value: "email", label: "email" },
 ];
 class NewSchedule extends Component {
   state = {
     values: [],
-    stuff: [],
-    selectedOption: null,
     start_date: Date,
     end_date: Date,
     title: "",
@@ -44,11 +41,6 @@ class NewSchedule extends Component {
       return { ...provided, opacity, transition };
     },
   };
-
-  handleChange = (selectedOption) => {
-    this.setState({ selectedOption });
-  };
-
   // stuff for new inputs
   createUI = () => {
     return this.state.values.map((el, i) => (
@@ -58,7 +50,7 @@ class NewSchedule extends Component {
             name={el.value + " "}
             type="input"
             value={this.state.values[i].value}
-            onChange={this.handleChanges.bind(this, i)}
+            onChange={this.handleChangesInput.bind(this, i)}
           />
           <Select
             value={this.state.values[i].selectedOption}
@@ -75,7 +67,7 @@ class NewSchedule extends Component {
             type="checkbox"
             defaultChecked={false}
             checked={this.state.values[i].isMandatory}
-            onChange={this.handleChanges.bind(this, i)}
+            onChange={this.handleCheckBox.bind(this, i)}
           />
           <input
             type="button"
@@ -87,23 +79,21 @@ class NewSchedule extends Component {
     ));
   };
 
-  handleChanges = (i, event, props) => {
-    console.log(i);
-    console.log(event);
-    console.log(props);
+  handleChangesInput = (i, event) => {
     let values = [...this.state.values];
-    let type = event.target.type;
-    values[i] = { ...values[i], [type]:  event.target.value };
+    values[i] = { ...values[i], input: event.target.value };
     this.setState({ values });
   };
 
-  handleChangeSelect = (i, event, props) => {
-    console.log(i);
-    console.log(event);
-    console.log(props);
+  handleChangeSelect = (i, event) => {
     let values = [...this.state.values];
-    let type = event.type;
-    values[i] = { ...values[i], [type]:  event.value };
+    values[i] = { ...values[i], select: event.value };
+    this.setState({ values });
+  };
+
+  handleCheckBox = (i, event) => {
+    let values = [...this.state.values];
+    values[i] = { ...values[i], isMandatory: event.target.checked };
     this.setState({ values });
   };
 
@@ -128,8 +118,6 @@ class NewSchedule extends Component {
     alert("hello");
   };
   render() {
-    const { selectedOption } = this.state;
-
     return (
       <div>
         <form onSubmit={this.handleSubmit}>
@@ -168,13 +156,13 @@ class NewSchedule extends Component {
               <input
                 type="date"
                 name="start_date"
-                value={this.state.start_date  ?! this.state.end_date : ""}
+                value={this.state.start_date ? !this.state.end_date : ""}
                 onChange={(e) => this.setState({ start_date: e.target.value })}
               />
               <input
                 type="date"
                 name="end_date"
-                value={ this.state.end_date ?! this.state.start_date : ""}
+                value={this.state.end_date ? !this.state.start_date : ""}
                 onChange={(e) => this.setState({ end_date: e.target.value })}
               />
               {/* {console.log(this.state.start_date)}

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -6,6 +6,8 @@ import { newSchedule } from "../services/scheduleService";
 import styles from "../assets/css/delete-account.module.css";
 import Joi from "joi";
 import { createUI } from "../components/CreateUI";
+import ColorPicker from "../components/ColorPicker";
+
 const options = [
   { value: "text", label: "Text" },
   { value: "number", label: "Only Numbers" },
@@ -154,11 +156,11 @@ class NewSchedule extends Form {
     this.routeChange(responseUuid);
   };
 
-  chooseColor = (event) => {
-    event.preventDefault();
-    console.log(event.target.id);
-    this.setState({ chosenColor: event.target.id });
+  chooseColor = (color) => {
+    console.log(color);
+    this.setState({ chosenColor: color });
   };
+
   render() {
     return (
       <div>
@@ -191,64 +193,10 @@ class NewSchedule extends Form {
               </div>
             </div>
             <div>{this.createUI()}</div>
-            <div>
-              <label className="form-control">Colors</label>
-              <div className={styles.colorContainer}>
-                <div className={styles.colorLabel}> Selected Color: </div>
-                <div
-                  className={styles.selectedColor}
-                  style={{ backgroundColor: this.state.chosenColor }}
-                >
-                  {" "}
-                </div>
-                <div className={styles.colorLabel}> Available Colors: </div>
-                <div
-                  className={styles.colorButton}
-                  id="#16a3a3"
-                  style={{ backgroundColor: "#16a3a3" }}
-                  onClick={this.chooseColor}
-                >
-                  {" "}
-                  Default{" "}
-                </div>
-                <div
-                  className={styles.colorButton}
-                  id="#f3947c"
-                  style={{ backgroundColor: "#f3947c" }}
-                  onClick={this.chooseColor}
-                >
-                  {" "}
-                  Peach
-                </div>
-                <div
-                  className={styles.colorButton}
-                  id="#a693bc"
-                  style={{ backgroundColor: "#a693bc" }}
-                  onClick={this.chooseColor}
-                >
-                  {" "}
-                  Lilac
-                </div>
-                <div
-                  className={styles.colorButton}
-                  id="#353839"
-                  style={{ backgroundColor: "#353839" }}
-                  onClick={this.chooseColor}
-                >
-                  {" "}
-                  Onyx
-                </div>
-                <div
-                  className={styles.colorButton}
-                  id="#e39e59"
-                  style={{ backgroundColor: "#e39e59" }}
-                  onClick={this.chooseColor}
-                >
-                  {" "}
-                  Ochre
-                </div>
-              </div>
-            </div>
+            <ColorPicker
+              chooseColor={this.chooseColor}
+              chosenColor={this.state.chosenColor}
+            />
             <div>
               Want to have custom schedule duration?{" "}
               <input

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -62,7 +62,7 @@ class NewSchedule extends Component {
           />
           <Select
             value={this.state.values[i].selectedOption}
-            onChange={this.handleChanges.bind(this, i)}
+            onChange={this.handleChangeSelect.bind(this, i)}
             options={options}
             width="200px"
             menuColor="red"
@@ -93,7 +93,17 @@ class NewSchedule extends Component {
     console.log(props);
     let values = [...this.state.values];
     let type = event.target.type;
-    values[i] = { ...values[i], [type]: event.target.value };
+    values[i] = { ...values[i], [type]:  event.target.value };
+    this.setState({ values });
+  };
+
+  handleChangeSelect = (i, event, props) => {
+    console.log(i);
+    console.log(event);
+    console.log(props);
+    let values = [...this.state.values];
+    let type = event.type;
+    values[i] = { ...values[i], [type]:  event.value };
     this.setState({ values });
   };
 
@@ -158,13 +168,13 @@ class NewSchedule extends Component {
               <input
                 type="date"
                 name="start_date"
-                value={this.state.start_date || ""}
+                value={this.state.start_date  ?! this.state.end_date : ""}
                 onChange={(e) => this.setState({ start_date: e.target.value })}
               />
               <input
                 type="date"
                 name="end_date"
-                value={this.state.end_date || ""}
+                value={ this.state.end_date ?! this.state.start_date : ""}
                 onChange={(e) => this.setState({ end_date: e.target.value })}
               />
               {/* {console.log(this.state.start_date)}

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Component } from "react";
+import { Modal, Button } from "react-bootstrap";
+import { useHistory } from "react-router-dom";
+import Select from "react-select";
+
+import styles from "../assets/css/delete-account.module.css";
+const options = [
+  { value: "chocolate", label: "Chocolate" },
+  { value: "strawberry", label: "Strawberry" },
+  { value: "vanilla", label: "Vanilla" },
+  { value: "email", label: "Email" },
+];
+class NewSchedule extends Component {
+  state = {
+    selectedOption: null,
+    start_date: Date,
+    end_date: Date,
+    title: "",
+    updateTitle: "",
+    description: "",
+    updateDescription: "",
+  };
+  backToUserpage = () => {
+    useHistory.push("/");
+  };
+
+  handleChange(e) {
+    this.setState({ id: e.value, name: e.label });
+  }
+  handleChange = (selectedOption) => {
+    this.setState({ selectedOption });
+    console.log(`Option selected:`, selectedOption);
+  };
+
+  render() {
+    const { selectedOption } = this.state;
+    return (
+      <div>
+        <div>
+          <div>
+            {/* required inputs */}
+            <div className="form-group">
+              <label>Give your schedule a Title</label>
+              <input
+                className="form-control"
+                value={this.state.title || ""}
+                onChange={(e) => this.updateTitle(e.target.value)}
+              />
+              <label>Please give a short description</label>
+              <input
+                className="form-control"
+                value={this.state.description || ""}
+                onChange={(e) => this.updateDescription(e.target.value)}
+              />
+            </div>
+          </div>
+          <div>
+            <Select
+              value={selectedOption}
+              onChange={this.handleChange}
+              options={options}
+            />
+            {/* extra stuff */}
+            <div>
+              <button>Add new stuff</button>
+            </div>
+          </div>
+          <div>
+            <div>Here be the colors? RGB color wheel?</div>
+            <input name="color picker" type="color"></input>
+          </div>
+          <div>
+            two data input fields here?
+            <input
+              type="date"
+              name="start_date"
+              value={this.state.start_date || ""}
+              onChange={(e) => this.setState({ start_date: e.target.value })}
+            />
+            <input
+              type="date"
+              name="end_date"
+              value={this.state.end_date || ""}
+              onChange={(e) => this.setState({ end_date: e.target.value })}
+            />
+            {console.log(this.state.start_date)}
+            {console.log(this.state.end_date)}
+            {/* somehow also to do endless? no end date */}
+          </div>
+          {/* button div */}
+          <div>
+            <Button className={styles.cancel} onClick={this.backToUserpage}>
+              Back
+            </Button>
+            <Button
+              className="btn-success"
+              onClick={() => {
+                this.handleNewSchedule();
+              }}
+            >
+              Create this schedule
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+export default NewSchedule;

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -28,6 +28,7 @@ class NewSchedule extends Component {
   backToUserpage = () => {
     useHistory.push("/");
   };
+
   routeChange = (path) => {
     useHistory.push("/view-schedule/" + path);
   };
@@ -146,9 +147,10 @@ class NewSchedule extends Component {
       },
       schedule_color: "#16a3a3",
     };
-    console.log(scheduleData);
-    scheduleData = await newSchedule(scheduleData);
-    this.routeChange(scheduleData[0].uuid);
+    let responseData = await newSchedule(scheduleData);
+    console.log(responseData);
+    console.log(responseData.data[0].uuid);
+    this.routeChange(responseData.data[0].uuid);
   };
 
   chooseColor = (event) => {

--- a/planetti-ui/src/components/NewSchedule.jsx
+++ b/planetti-ui/src/components/NewSchedule.jsx
@@ -1,23 +1,27 @@
 import React from "react";
 import { Component } from "react";
-import { Button } from "react-bootstrap";
+import { Button, ToastBody } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 import Select from "react-select";
 
 import styles from "../assets/css/delete-account.module.css";
+
 const options = [
   { value: "chocolate", label: "Chocolate", type: "select" },
   { value: "strawberry", label: "Strawberry", type: "select" },
   { value: "vanilla", label: "Vanilla", type: "select" },
   { value: "email", label: "Email", type: "select" },
 ];
+
+const todayDate = new Date;
+
 class NewSchedule extends Component {
   state = {
     values: [],
     stuff: [],
     selectedOption: null,
-    start_date: Date,
-    end_date: Date,
+    start_date: todayDate.toISOString().slice(0,10),
+    end_date: todayDate.toISOString().slice(0,10),
     title: "",
     description: "",
   };
@@ -159,22 +163,19 @@ class NewSchedule extends Component {
               {this.createUI()}
               <input type="submit" value="test submit" />
             </div>
-            <div>
-              <div>Here be the colors? RGB color wheel?</div>
-              <input name="color picker" type="color"></input>
-            </div>
+              <label>Colors~~~</label>
             <div>
               two data input fields here?
               <input
                 type="date"
                 name="start_date"
-                value={this.state.start_date  ?! this.state.end_date : ""}
+                value={this.state.start_date}
                 onChange={(e) => this.setState({ start_date: e.target.value })}
               />
               <input
                 type="date"
                 name="end_date"
-                value={ this.state.end_date ?! this.state.start_date : ""}
+                value={ this.state.end_date}
                 onChange={(e) => this.setState({ end_date: e.target.value })}
               />
               {/* {console.log(this.state.start_date)}

--- a/planetti-ui/src/components/SingleSchedule.jsx
+++ b/planetti-ui/src/components/SingleSchedule.jsx
@@ -7,7 +7,7 @@ function SingleSchedule(props) {
   return (
     <div className={styles.grid_item}>
     <Card style={{ width: "100%" }}>
-      <Card.Body className={styles.card_style}>
+      <Card.Body className={styles.card_style}  style={{backgroundColor:props.schedule_color}}>
         <div key={props.schedule_id}>
           <Link
             to={`/view-schedule/${props.uuid}`}

--- a/planetti-ui/src/components/Userpage.jsx
+++ b/planetti-ui/src/components/Userpage.jsx
@@ -71,7 +71,8 @@ const Userpage = () => {
     updateDescription("");
   };
   const handleNewScheduleShow = () => {
-    setShowNewSchedule(true);
+    // setShowNewSchedule(true);
+    history.push("/new-schedule/");
   };
   const handleNewSchedule = async () => {
     console.log(title);
@@ -127,58 +128,67 @@ const Userpage = () => {
   return (
     <div>
       <div className={styles2.centerContent}>
-      <div className={styles2.gridContainer}>
-      <div onClick={handleNewScheduleShow}  className={styles2.clickDiv}>
-        Add New Schedule
-      </div>
-      {schedules.map((single) => (
-        <SingleSchedule
-          deleteSchedule={handleDeleteShow}
-          editSchedule={handleEditScheduleShow}
-          key={single.schedule_id}
-          {...single}
-        />
-      ))}
-      </div>
-      <div>
-        {/* Modal start for new schedule */}
-        <Modal centered show={showNewSchedule} onHide={handleNewScheduleClose}>
-          <Modal.Header closeButton>
-            <Modal.Title className={styles["modal-title"]}>
-              Create New schedule
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-          <div className="form-group">
-            <label>Give your schedule a Title</label>
-            <input className="form-control"
-              value={title || ""}
-              onChange={(e) => updateTitle(e.target.value)}
+        <div className={styles2.gridContainer}>
+          <div onClick={handleNewScheduleShow} className={styles2.clickDiv}>
+            Add New Schedule
+          </div>
+          {schedules.map((single) => (
+            <SingleSchedule
+              deleteSchedule={handleDeleteShow}
+              editSchedule={handleEditScheduleShow}
+              key={single.schedule_id}
+              {...single}
             />
-            <hr></hr>
-            <label>Please give a short description</label>
-            <input className="form-control"
-              value={description || ""}
-              onChange={(e) => updateDescription(e.target.value)}
-            />
-            </div>
-          </Modal.Body>
-          <Modal.Footer className={styles["modal-footer"]}>
-          <Button className={styles.cancel} onClick={handleNewScheduleClose}>
-              Cancel
-            </Button>
-            <Button
-              className="btn-success"
-              onClick={() => {
-                handleNewSchedule();
-              }}
-            >
-              Create new schedule
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      </div>
+          ))}
         </div>
+        <div>
+          {/* Modal start for new schedule */}
+          <Modal
+            centered
+            show={showNewSchedule}
+            onHide={handleNewScheduleClose}
+          >
+            <Modal.Header closeButton>
+              <Modal.Title className={styles["modal-title"]}>
+                Create New schedule
+              </Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <div className="form-group">
+                <label>Give your schedule a Title</label>
+                <input
+                  className="form-control"
+                  value={title || ""}
+                  onChange={(e) => updateTitle(e.target.value)}
+                />
+                <hr></hr>
+                <label>Please give a short description</label>
+                <input
+                  className="form-control"
+                  value={description || ""}
+                  onChange={(e) => updateDescription(e.target.value)}
+                />
+              </div>
+            </Modal.Body>
+            <Modal.Footer className={styles["modal-footer"]}>
+              <Button
+                className={styles.cancel}
+                onClick={handleNewScheduleClose}
+              >
+                Cancel
+              </Button>
+              <Button
+                className="btn-success"
+                onClick={() => {
+                  handleNewSchedule();
+                }}
+              >
+                Create new schedule
+              </Button>
+            </Modal.Footer>
+          </Modal>
+        </div>
+      </div>
       <div>
         {/* Modal starts for deleting single event */}
         <Modal centered show={showDeleteConfirm} onHide={handleDeleteClose}>
@@ -189,15 +199,15 @@ const Userpage = () => {
           </Modal.Header>
           <Modal.Body className={styles["modal-body"]}>
             <div class={styles2.buttonBar}>
-            <Button
-              className="btn-danger"
-              onClick={() => handleDelete(scheduleID)}
-            >
-              Delete schedule
-            </Button>
-            <Button className={styles.cancel} onClick={handleDeleteClose}>
-              Cancel
-            </Button>
+              <Button
+                className="btn-danger"
+                onClick={() => handleDelete(scheduleID)}
+              >
+                Delete schedule
+              </Button>
+              <Button className={styles.cancel} onClick={handleDeleteClose}>
+                Cancel
+              </Button>
             </div>
           </Modal.Body>
         </Modal>
@@ -216,19 +226,21 @@ const Userpage = () => {
             </Modal.Title>
           </Modal.Header>
           <Modal.Body className={styles["modal-body"]}>
-          <div className="form-group">
-            <label>Edit a Title</label>
-            <input className="form-control"
-              value={title || ""}
-              onChange={(e) => updateTitle(e.target.value)}
-            />
-            <hr></hr>
-            <label>edit your description</label>
-            <input className="form-control"
-              value={description || ""}
-              onChange={(e) => updateDescription(e.target.value)}
-            />
-             </div>
+            <div className="form-group">
+              <label>Edit a Title</label>
+              <input
+                className="form-control"
+                value={title || ""}
+                onChange={(e) => updateTitle(e.target.value)}
+              />
+              <hr></hr>
+              <label>edit your description</label>
+              <input
+                className="form-control"
+                value={description || ""}
+                onChange={(e) => updateDescription(e.target.value)}
+              />
+            </div>
           </Modal.Body>
           <Modal.Footer className={styles["modal-footer"]}>
             <Button

--- a/planetti-ui/src/components/Userpage.jsx
+++ b/planetti-ui/src/components/Userpage.jsx
@@ -37,7 +37,7 @@ const Userpage = () => {
       const userInfo = localStorage.getItem("userInfo");
       const { user_id } = JSON.parse(userInfo);
       const { data } = await getSchedules(user_id);
-      setSchedules(data);
+      setSchedules(data.reverse());
     }
     fetchData();
     //so gets all the schedules for given user id

--- a/planetti-ui/src/components/ViewSchedule.jsx
+++ b/planetti-ui/src/components/ViewSchedule.jsx
@@ -150,11 +150,27 @@ const ViewSchedule = ({ match, history }) => {
   /* Utils
   ---------*/
   const setMinDate = minDate => {
-    return new Date(minDate).toDateString() || new Date(1900, 0, 1);
+    if (minDate == "")
+    {
+      return new Date(1900, 0, 1)
+    }
+    else
+    {
+    return new Date(minDate).toDateString()
+    }
+   // return new Date(minDate).toDateString() || new Date(1900, 0, 1);
   };
 
   const setMaxDate = maxDate => {
-    return new Date(maxDate).toDateString() || new Date(2099, 11, 31);
+    if (maxDate == "")
+    {
+      return new Date(2099, 11, 31)
+    }
+    else
+    {
+    return new Date(maxDate).toDateString()
+    }
+    //return new Date(maxDate).toDateString() || new Date(2099, 11, 31);
   };
 
   const isCustomFields = _ => {

--- a/planetti-ui/src/services/scheduleService.js
+++ b/planetti-ui/src/services/scheduleService.js
@@ -16,11 +16,13 @@ export function getScheduleByUUID(UUID) {
 
 //create new schedule for this user_id
 export function newSchedule(schedule) {
-  const { title, description, user_id } = schedule
+  const { title, description, user_id,schedule_config,schedule_color } = schedule
   return http.post(schedulesAPI, {
     title,
     description,
-    user_id
+    user_id,
+    schedule_config,
+    schedule_color
   });
 }
 


### PR DESCRIPTION
Create new schedule page functionality. 
Style fixes, new schedule page still needs to get styling. 
Wrapper for main page, pushes footer to bottom.
Edit in view-schedule.jsx, if statements for the data objects now makes the schedule open schedule objects with "" for date. 
If the limited range checkbox is selected or unselected, the state will change accordingly.